### PR TITLE
'tls-server' shouldn't be used with 'secret'

### DIFF
--- a/openvpn/files/server.jinja
+++ b/openvpn/files/server.jinja
@@ -6,7 +6,9 @@
 
 
 {%- if not (config.tls_server is defined and config.tls_server == False) %}
+{%- if not (config.secret is defined) %}
 tls-server
+{%- endif %}
 {%- endif %}
 
 {%- if config.local is defined %}


### PR DESCRIPTION
i ran into the following openvpn error message: "Options error: specify only one of --tls-server, --tls-client, or --secret"